### PR TITLE
[Support] Branch linting

### DIFF
--- a/.github/workflows/branchlint.yml
+++ b/.github/workflows/branchlint.yml
@@ -1,0 +1,17 @@
+name: Branch Lint
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: lekterable/branchlint-action@v1.0.0
+      with:
+        allowed: /(master|develop|(((release)\/(v)?(?:([0-9](\.)?)+)?|(feature|bugfix|support)\/([a-zA-Z0-9_-]+)))|(dependabot)\/[a-zA-Z_-]+\/[a-zA-Z0-9_\-\.]+)/


### PR DESCRIPTION
Adds a workflow for branch linting; Preventing users from pushing, or creating a pull-request that do not follow the branch naming conventions.

Proposed conventions:
- `master`
- `develop`
- `release/[v][release][.major][.minor]`
- `feature/[name_with_underscores_or_dashes]`
- `bugfix/[name_with_underscores_or_dashes]`
- `support/[name_with_underscores_or_dashes]`

**Note:** The branches that dependabot creates are also validated, these are specific to dependabot and should not be used by people in general.